### PR TITLE
add text to mime-types.txt

### DIFF
--- a/config/mime-types.txt
+++ b/config/mime-types.txt
@@ -57,3 +57,5 @@ lic;application/octet-stream;;true
 cor;application/octet-stream;;true
 woff2;application/font-woff2;;true
 gitignore;text/plain;;false
+npld;npld/text;;true 
+npls;npls/text;;true 


### PR DESCRIPTION
Hallo,

ich habe die File Extension für np-Geomap in die mime-types.txt hinzugefügt.

Viele Grüße Thomas
